### PR TITLE
Pact CLI docs feature basic implementation

### DIFF
--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'pact/cli/run_pact_verification'
+require 'pact/cli/generate_pact_docs'
 
 module Pact
   class CLI < Thor
@@ -13,6 +14,11 @@ module Pact
 
     def verify
       Cli::RunPactVerification.call(options)
+    end
+
+    desc 'docs', "Generate pact documentation"
+    def docs
+      Pact::Doc::Generate.call('./pacts', './doc/pacts', [Pact::Doc::Markdown::Generator])
     end
 
   end

--- a/lib/pact/cli/generate_pact_docs.rb
+++ b/lib/pact/cli/generate_pact_docs.rb
@@ -1,0 +1,4 @@
+require 'pact/doc/doc_file'
+require 'pact/doc/generate'
+require 'pact/doc/markdown/generator'
+require 'pact/consumer'


### PR DESCRIPTION
- Exposed Pact docs generation to a thor command
- Using default i/o locations (./pacts and ./doc/pact respectively)
- Markdown renderer is hardcoded atm