### PR TITLE
Basic auth

### DIFF
--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -7,6 +7,8 @@ module Pact
     desc 'verify', "Verify a pact"
     method_option :pact_helper, aliases: "-h", desc: "Pact helper file", :required => true
     method_option :pact_uri, aliases: "-p", desc: "Pact URI"
+    method_option :pact_repository_username, aliases: "-u", desc: "Pact repository user name"
+    method_option :pact_repository_password, aliases: "-w", desc: "Pact repository password"
     method_option :backtrace, aliases: "-b", desc: "Show full backtrace", :default => false, :type => :boolean
     method_option :description, aliases: "-d", desc: "Interaction description filter"
     method_option :provider_state, aliases: "-s", desc: "Provider state filter"

--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -7,8 +7,8 @@ module Pact
     desc 'verify', "Verify a pact"
     method_option :pact_helper, aliases: "-h", desc: "Pact helper file", :required => true
     method_option :pact_uri, aliases: "-p", desc: "Pact URI"
-    method_option :pact_repository_username, aliases: "-u", desc: "Pact repository user name"
-    method_option :pact_repository_password, aliases: "-w", desc: "Pact repository password"
+    method_option :pact_broker_username, aliases: "-u", desc: "Pact broker user name"
+    method_option :pact_broker_password, aliases: "-w", desc: "Pact broker password"
     method_option :backtrace, aliases: "-b", desc: "Show full backtrace", :default => false, :type => :boolean
     method_option :description, aliases: "-d", desc: "Interaction description filter"
     method_option :provider_state, aliases: "-s", desc: "Provider state filter"

--- a/lib/pact/cli/run_pact_verification.rb
+++ b/lib/pact/cli/run_pact_verification.rb
@@ -53,7 +53,11 @@ module Pact
       end
 
       def run_with_pact_uri
-        Pact::Provider::PactSpecRunner.new([options[:pact_uri]], pact_spec_options).run
+        pact_repository_uri_options = {}
+        pact_repository_uri_options[:username] = options[:pact_repository_username] if options[:pact_repository_username]
+        pact_repository_uri_options[:password] = options[:pact_repository_password] if options[:pact_repository_password]
+        pact_repository_uri = ::Pact::Provider::PactRepositoryUri.new(options[:pact_uri], pact_repository_uri_options)
+        Pact::Provider::PactSpecRunner.new([pact_repository_uri], pact_spec_options).run
       end
 
       def run_with_configured_pacts

--- a/lib/pact/cli/run_pact_verification.rb
+++ b/lib/pact/cli/run_pact_verification.rb
@@ -54,8 +54,8 @@ module Pact
 
       def run_with_pact_uri
         pact_repository_uri_options = {}
-        pact_repository_uri_options[:username] = options[:pact_repository_username] if options[:pact_repository_username]
-        pact_repository_uri_options[:password] = options[:pact_repository_password] if options[:pact_repository_password]
+        pact_repository_uri_options[:username] = options[:pact_broker_username] if options[:pact_broker_username]
+        pact_repository_uri_options[:password] = options[:pact_broker_password] if options[:pact_broker_password]
         pact_repository_uri = ::Pact::Provider::PactRepositoryUri.new(options[:pact_uri], pact_repository_uri_options)
         Pact::Provider::PactSpecRunner.new([pact_repository_uri], pact_spec_options).run
       end

--- a/lib/pact/provider/configuration/pact_verification.rb
+++ b/lib/pact/provider/configuration/pact_verification.rb
@@ -1,4 +1,5 @@
 require 'pact/provider/pact_verification'
+require 'pact/provider/pact_repository_uri'
 require 'pact/shared/dsl'
 require 'pact/provider/world'
 
@@ -20,8 +21,8 @@ module Pact
         end
 
         dsl do
-          def pact_uri pact_uri
-            self.pact_uri = pact_uri
+          def pact_uri pact_uri, options = {}
+            self.pact_uri = ::Pact::Provider::PactRepositoryUri.new(pact_uri, options) if pact_uri
           end
         end
 

--- a/lib/pact/provider/pact_repository_uri.rb
+++ b/lib/pact/provider/pact_repository_uri.rb
@@ -1,0 +1,18 @@
+module Pact
+  module Provider
+    class PactRepositoryUri
+      attr_reader :uri, :options
+
+      def initialize (uri, options={})
+        @uri = uri
+        @options = options
+      end
+
+      def == other
+        other.is_a?(PactRepositoryUri) &&
+          uri == other.uri &&
+          options == other.options
+      end
+    end
+  end
+end

--- a/lib/pact/provider/pact_source.rb
+++ b/lib/pact/provider/pact_source.rb
@@ -11,7 +11,7 @@ module PactBroker
       end
 
       def pact_json
-        @pact_json ||= Pact::PactFile.read(uri, {})
+        @pact_json ||= Pact::PactFile.read(uri.uri, uri.options)
       end
 
     end

--- a/lib/pact/provider/rspec.rb
+++ b/lib/pact/provider/rspec.rb
@@ -20,7 +20,7 @@ module Pact
 
         def honour_pactfile pact_uri, pact_json, options
           #TODO change puts to use output stream
-          puts "Reading pact at #{pact_uri}"
+          puts "Reading pact at #{pact_uri.uri}"
           puts "Filtering interactions by: #{options[:criteria]}" if options[:criteria] && options[:criteria].any?
           consumer_contract = Pact::ConsumerContract.from_json(pact_json)
           ::RSpec.describe "Verifying a pact between #{consumer_contract.consumer.name} and #{consumer_contract.provider.name}", :pactfile_uri => pact_uri do

--- a/lib/pact/tasks/task_helper.rb
+++ b/lib/pact/tasks/task_helper.rb
@@ -25,8 +25,8 @@ module Pact
       command_parts << "-S pact verify"
       command_parts << "--pact-helper" << (pact_helper.end_with?(".rb") ? pact_helper : pact_helper + ".rb")
       (command_parts << "--pact-uri" << pact_uri) if pact_uri
-      command_parts << "--pact_repository_username" << ENV['PACT_REPO_USERNAME'] if ENV['PACT_REPO_USERNAME']
-      command_parts << "--pact_repository_password" << ENV['PACT_REPO_PASSWORD'] if ENV['PACT_REPO_PASSWORD']
+      command_parts << "--pact-repository-username" << ENV['PACT_REPO_USERNAME'] if ENV['PACT_REPO_USERNAME']
+      command_parts << "--pact-repository-password" << ENV['PACT_REPO_PASSWORD'] if ENV['PACT_REPO_PASSWORD']
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--description #{Shellwords.escape(ENV['PACT_DESCRIPTION'])}" if ENV['PACT_DESCRIPTION']

--- a/lib/pact/tasks/task_helper.rb
+++ b/lib/pact/tasks/task_helper.rb
@@ -25,6 +25,9 @@ module Pact
       command_parts << "-S pact verify"
       command_parts << "--pact-helper" << (pact_helper.end_with?(".rb") ? pact_helper : pact_helper + ".rb")
       (command_parts << "--pact-uri" << pact_uri) if pact_uri
+      command_parts << "--pact_repository_username" << ENV['PACT_REPO_USERNAME'] if ENV['PACT_REPO_USERNAME']
+      command_parts << "--pact_repository_password" << ENV['PACT_REPO_PASSWORD'] if ENV['PACT_REPO_PASSWORD']
+      command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--description #{Shellwords.escape(ENV['PACT_DESCRIPTION'])}" if ENV['PACT_DESCRIPTION']
       command_parts << "--provider-state #{Shellwords.escape(ENV['PACT_PROVIDER_STATE'])}" if ENV['PACT_PROVIDER_STATE']

--- a/lib/pact/tasks/task_helper.rb
+++ b/lib/pact/tasks/task_helper.rb
@@ -25,8 +25,8 @@ module Pact
       command_parts << "-S pact verify"
       command_parts << "--pact-helper" << (pact_helper.end_with?(".rb") ? pact_helper : pact_helper + ".rb")
       (command_parts << "--pact-uri" << pact_uri) if pact_uri
-      command_parts << "--pact-repository-username" << ENV['PACT_REPO_USERNAME'] if ENV['PACT_REPO_USERNAME']
-      command_parts << "--pact-repository-password" << ENV['PACT_REPO_PASSWORD'] if ENV['PACT_REPO_PASSWORD']
+      command_parts << "--pact-broker-username" << ENV['PACT_BROKER_USERNAME'] if ENV['PACT_BROKER_USERNAME']
+      command_parts << "--pact-broker-password" << ENV['PACT_BROKER_PASSWORD'] if ENV['PACT_BROKER_PASSWORD']
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--description #{Shellwords.escape(ENV['PACT_DESCRIPTION'])}" if ENV['PACT_DESCRIPTION']

--- a/spec/lib/pact/provider/configuration/pact_verification_spec.rb
+++ b/spec/lib/pact/provider/configuration/pact_verification_spec.rb
@@ -8,6 +8,12 @@ module Pact
 
         describe 'create_verification' do
           let(:url) {'http://some/uri'}
+          let(:pact_repository_uri_options) do
+            {
+              username: 'pact_broker_username',
+              password: 'pact_broker_password'
+            }
+          end
           let(:consumer_name) {'some consumer'}
           let(:ref) {:prod}
           let(:options) { {:ref => :prod} }
@@ -15,12 +21,13 @@ module Pact
             subject do
               uri = url
               PactVerification.build(consumer_name, options) do
-                pact_uri uri
+                pact_uri uri, pact_repository_uri_options
               end
             end
 
             it "creates a Verification" do
-              expect(Pact::Provider::PactVerification).to receive(:new).with(consumer_name, url, ref)
+              pact_repository_uri = Pact::Provider::PactRepositoryUri.new(url, pact_repository_uri_options)
+              expect(Pact::Provider::PactVerification).to receive(:new).with(consumer_name, pact_repository_uri, ref)
               subject
             end
           end

--- a/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
+++ b/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'pact/provider/configuration/service_provider_dsl'
+require 'pact/provider/pact_repository_uri'
 
 module Pact
 
@@ -51,34 +52,43 @@ module Pact
           before do
             Pact.clear_provider_world
           end
+          let(:pact_url) { 'blah'}
 
           context "with no optional params" do
             subject do
               ServiceProviderDSL.build 'some-provider' do
                 app {}
                 honours_pact_with 'some-consumer' do
-                  pact_uri 'blah'
+                  pact_uri pact_url
                 end
               end
             end
             it 'adds a verification to the Pact.provider_world' do
               subject
-              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', 'blah', :head))
+              pact_repository_uri = Pact::Provider::PactRepositoryUri.new(pact_url)
+              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', pact_repository_uri, :head))
             end
           end
 
           context "with all params specified" do
+            let(:pact_uri_options) do
+              {
+                username: 'pact_user',
+                password: 'pact_pw'
+              }
+            end
             subject do
               ServiceProviderDSL.build 'some-provider' do
                 app {}
                 honours_pact_with 'some-consumer', :ref => :prod do
-                  pact_uri 'blah'
+                  pact_uri pact_url, pact_uri_options
                 end
               end
             end
             it 'adds a verification to the Pact.provider_world' do
               subject
-              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', 'blah', :prod))
+              pact_repository_uri = Pact::Provider::PactRepositoryUri.new(pact_url, pact_uri_options)
+              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', pact_repository_uri , :prod))
             end
 
           end

--- a/spec/lib/pact/provider/pact_repository_uri_spec.rb
+++ b/spec/lib/pact/provider/pact_repository_uri_spec.rb
@@ -1,0 +1,24 @@
+describe Pact::Provider::PactRepositoryUri do
+  let(:uri) { 'http://uri'}
+  let(:username) { 'pact'}
+  let(:options) { {username: username}}
+  let(:pact_repository_uri) { Pact::Provider::PactRepositoryUri.new(uri, options)}
+  describe '#==' do
+
+    it 'should return false if object is not PactRepositoryUri' do
+      expect(pact_repository_uri == Object.new).to be false
+    end
+
+    it 'should return false if uri is not equal' do
+      expect(pact_repository_uri == Pact::Provider::PactRepositoryUri.new('other_uri', options)).to be false
+    end
+
+    it 'should return false if uri options are not equal' do
+      expect(pact_repository_uri == Pact::Provider::PactRepositoryUri.new(uri, {username: 'wrong user'})).to be false
+    end
+
+    it 'should return true if uri and options are equal' do
+      expect(pact_repository_uri == Pact::Provider::PactRepositoryUri.new(uri, options)).to be true
+    end
+  end
+end

--- a/spec/lib/pact/tasks/task_helper_spec.rb
+++ b/spec/lib/pact/tasks/task_helper_spec.rb
@@ -58,33 +58,33 @@ module Pact
         end
       end
 
-      context "with PACT_REPO_USERNAME set" do
+      context "with PACT_BROKER_USERNAME set" do
         before do
-          ENV['PACT_REPO_USERNAME'] = 'pact_username'
+          ENV['PACT_BROKER_USERNAME'] = 'pact_username'
         end
 
         it "includes the -u option in the command" do
-          expect(TaskHelper).to receive(:execute_cmd).with(/--pact_repository_username pact_username/)
+          expect(TaskHelper).to receive(:execute_cmd).with(/--pact-broker-username pact_username/)
           TaskHelper.execute_pact_verify(pact_uri, nil, nil)
         end
 
         after do
-          ENV.delete('PACT_REPO_USERNAME')
+          ENV.delete('PACT_BROKER_USERNAME')
         end
       end
 
-      context "with PACT_REPO_PASSWORD set" do
+      context "with PACT_BROKER_PASSWORD set" do
         before do
-          ENV['PACT_REPO_PASSWORD'] = 'pact_password'
+          ENV['PACT_BROKER_PASSWORD'] = 'pact_password'
         end
 
         it "includes the -w option in the command" do
-          expect(TaskHelper).to receive(:execute_cmd).with(/--pact_repository_password pact_password/)
+          expect(TaskHelper).to receive(:execute_cmd).with(/--pact-broker-password pact_password/)
           TaskHelper.execute_pact_verify(pact_uri, nil, nil)
         end
 
         after do
-          ENV.delete('PACT_REPO_PASSWORD')
+          ENV.delete('PACT_BROKER_PASSWORD')
         end
       end
 

--- a/spec/lib/pact/tasks/task_helper_spec.rb
+++ b/spec/lib/pact/tasks/task_helper_spec.rb
@@ -58,6 +58,36 @@ module Pact
         end
       end
 
+      context "with PACT_REPO_USERNAME set" do
+        before do
+          ENV['PACT_REPO_USERNAME'] = 'pact_username'
+        end
+
+        it "includes the -u option in the command" do
+          expect(TaskHelper).to receive(:execute_cmd).with(/--pact_repository_username pact_username/)
+          TaskHelper.execute_pact_verify(pact_uri, nil, nil)
+        end
+
+        after do
+          ENV.delete('PACT_REPO_USERNAME')
+        end
+      end
+
+      context "with PACT_REPO_PASSWORD set" do
+        before do
+          ENV['PACT_REPO_PASSWORD'] = 'pact_password'
+        end
+
+        it "includes the -w option in the command" do
+          expect(TaskHelper).to receive(:execute_cmd).with(/--pact_repository_password pact_password/)
+          TaskHelper.execute_pact_verify(pact_uri, nil, nil)
+        end
+
+        after do
+          ENV.delete('PACT_REPO_PASSWORD')
+        end
+      end
+
       context "with rspec_opts" do
         it "includes the rspec_opts as SPEC_OPTS in the command" do
           expect(TaskHelper).to receive(:execute_cmd) do | command |


### PR DESCRIPTION
Hi,

I've forked the pact, pact-support and pact_broker-client repository and made the changes on the 'basic_auth' branch for each project and created pull request.

The main changes are:

#### pact-support
pass the basic auth option to PactFile open method

#### pact
* added the basic auth options in dsl 
```ruby
honours_pact_with 'ServiceConsumer' do
    pact_uri 'http://pact-broker-url/consumer/ServiceConsumer/latest', {username: 'user', password: 'pass'}
end
```
* when running pact:verify:at['pact_broker_url'] task, currently I just let users to set environment variables PACT_REPO_USERNAME, PACT_REPO_PASSWORD for the basic auth information.  I am not sure whether it's good enough.

#### pact_broker_client
 pass optional pact_broker_basic_auth in the PublicationTask

```ruby
task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} #optional 
```

#### Testing
* I've added unit tests for my changes.  The rake tasks of all the three projects all passed. 
* I used my version to run pact:verify, pact:verify:at['pact_url'] and publication task pointing to our pact broker with basic authentication and without basic authentication.  They both worked. 

#### Documentation:
I've updated the README.md file in the pact_broker-client project.  But for the pact:verify part, I am not sure where to put the examples.  


I am not sure whether my change matches your code convention. Please review my changes and I will revise based on your feedback.  Thanks.








