### PR TITLE
Update document about pactfile_write_mode

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -146,9 +146,9 @@ Default value: `./doc`
 ### pactfile_write_mode
 
 Default value: `:overwrite`
-Options: `:overwrite`, `:update`, `:smart`
+Options: `:overwrite`, `:update`, `:smart`, `:none`
 
-By default, the pact file will be overwritten (started from scratch) every time any rspec runs any spec using pacts. This means that if there are interactions that haven't been executed in the most recent rspec run, they are effectively removed from the pact file. If you have long running pact specs (e.g. they are generated using the browser with Capybara) and you are developing both consumer and provider in parallel, or trying to fix a broken interaction, it can be tedious to run all the specs at once. In this scenario, you can set the pactfile_write_mode to :update. This will keep all existing interactions, and update only the changed ones, identified by description and provider state. The down side of this is that if either of those fields change, the old interactions will not be removed from the pact file. As a middle path, you can set pactfile_write_mode to :smart. This will use :overwrite mode when running rake (as determined by a call to system using 'ps') and :update when running an individual spec.
+By default, the pact file will be overwritten (started from scratch) every time any rspec runs any spec using pacts. This means that if there are interactions that haven't been executed in the most recent rspec run, they are effectively removed from the pact file. If you have long running pact specs (e.g. they are generated using the browser with Capybara) and you are developing both consumer and provider in parallel, or trying to fix a broken interaction, it can be tedious to run all the specs at once. In this scenario, you can set the pactfile_write_mode to :update. This will keep all existing interactions, and update only the changed ones, identified by description and provider state. The down side of this is that if either of those fields change, the old interactions will not be removed from the pact file. As a middle path, you can set pactfile_write_mode to :smart. This will use :overwrite mode when running rake (as determined by a call to system using 'ps') and :update when running an individual spec. :none will not generate any pact files (with pact-mock_service >= 0.8.1).
 
 ## Provider
 


### PR DESCRIPTION
Add document about new `pactfile_write_mode` option. https://github.com/bethesque/pact-mock_service/commit/f2f87704ce68207b99621ba0072a7c3129569aaa#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR7