### PR TITLE
Load missing dependent library

### DIFF
--- a/lib/pact/doc/markdown/interaction_renderer.rb
+++ b/lib/pact/doc/markdown/interaction_renderer.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'pact/doc/interaction_view_model'
 
 module Pact


### PR DESCRIPTION
Missing 'erb' caused `NameError` in `spec/integration/cli_docs_spec.rb` which does not affect example failure though.

ref: https://travis-ci.org/realestate-com-au/pact/jobs/89347236#L922