### PR TITLE
Add interface to use find_available_port option

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'randexp', '~> 0.1.7'
   gem.add_runtime_dependency 'rspec', '>=2.14'
-  gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'rack-test', '~> 0.6.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.1'
   gem.add_runtime_dependency 'thor'

--- a/spec/lib/pact/consumer/configuration_spec.rb
+++ b/spec/lib/pact/consumer/configuration_spec.rb
@@ -3,83 +3,83 @@ require 'pact/consumer/configuration'
 
 module Pact::Consumer::Configuration
 
-   describe MockService do
+  describe MockService do
 
-      let(:world) { Pact::Consumer::World.new }
-      let(:port_number) { 1234 }
-      before do
-         Pact.clear_configuration
-         allow(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).and_return(port_number)
-         allow(Pact).to receive(:consumer_world).and_return(world)
+    let(:world) { Pact::Consumer::World.new }
+    let(:port_number) { 1234 }
+    before do
+      Pact.clear_configuration
+      allow(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).and_return(port_number)
+      allow(Pact).to receive(:consumer_world).and_return(world)
+    end
+
+    describe "configure_consumer_contract_builder" do
+      let(:consumer_name) {'consumer'}
+      subject {
+        MockService.build :mock_service, consumer_name, provider_name do
+          port port_number
+          standalone true
+          verify true
+        end
+      }
+
+      let(:provider_name) { 'Mock Provider' }
+      let(:consumer_contract_builder) { instance_double('Pact::Consumer::ConsumerContractBuilder') }
+      let(:url) { "http://localhost:#{port_number}" }
+
+      it "adds a verification to the Pact configuration" do
+        allow(Pact::Consumer::ConsumerContractBuilder).to receive(:new).and_return(consumer_contract_builder)
+        subject
+        expect(consumer_contract_builder).to receive(:verify)
+        Pact.configuration.provider_verifications.first.call
       end
 
-      describe "configure_consumer_contract_builder" do
-         let(:consumer_name) {'consumer'}
-         subject {
-            MockService.build :mock_service, consumer_name, provider_name do
-               port port_number
-               standalone true
-               verify true
-            end
-         }
-
-         let(:provider_name) { 'Mock Provider' }
-         let(:consumer_contract_builder) { instance_double('Pact::Consumer::ConsumerContractBuilder') }
-         let(:url) { "http://localhost:#{port_number}" }
-
-         it "adds a verification to the Pact configuration" do
-            allow(Pact::Consumer::ConsumerContractBuilder).to receive(:new).and_return(consumer_contract_builder)
-            subject
-            expect(consumer_contract_builder).to receive(:verify)
-            Pact.configuration.provider_verifications.first.call
-         end
-
-         context "when standalone" do
-            it "does not register the app with the AppManager" do
-               expect(Pact::MockService::AppManager.instance).to_not receive(:register_mock_service_for)
-               subject
-            end
-         end
-         context "when not standalone" do
-            subject {
-               MockService.build :mock_service, consumer_name, provider_name do
-                  port port_number
-                  standalone false
-                  verify true
-                  pact_specification_version '1'
-               end
-            }
-            it "registers the app with the AppManager" do
-               expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
-                 with(provider_name, url, pact_specification_version: '1', find_available_port: false).
-                 and_return(port_number)
-               subject
-            end
-         end
-
-         context "without port specification" do
-           let(:url) { 'http://localhost' }
-           subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
-
-           it "registers the app with the AppManager with find_available_port option" do
-             expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
-               with(provider_name, url, pact_specification_version: nil, find_available_port: true).
-               and_return(port_number)
-             subject
-           end
-         end
-
-         context "without port specification and old pact-mock_service" do
-           let(:url) { 'http://localhost' }
-           subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
-
-           it "checks and raises an error" do
-             expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
-               with(provider_name, url, pact_specification_version: nil, find_available_port: true).
-               and_return(nil)
-             expect { subject }.to raise_error(/pact-mock_service.+does not support/)
-           end
-         end
+      context "when standalone" do
+        it "does not register the app with the AppManager" do
+          expect(Pact::MockService::AppManager.instance).to_not receive(:register_mock_service_for)
+          subject
+        end
       end
-   end
+      context "when not standalone" do
+        subject {
+          MockService.build :mock_service, consumer_name, provider_name do
+            port port_number
+            standalone false
+            verify true
+            pact_specification_version '1'
+          end
+        }
+        it "registers the app with the AppManager" do
+          expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+            with(provider_name, url, pact_specification_version: '1', find_available_port: false).
+            and_return(port_number)
+          subject
+        end
+      end
+
+      context "without port specification" do
+        let(:url) { 'http://localhost' }
+        subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
+
+        it "registers the app with the AppManager with find_available_port option" do
+          expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+            with(provider_name, url, pact_specification_version: nil, find_available_port: true).
+            and_return(port_number)
+          subject
+        end
+      end
+
+      context "without port specification and old pact-mock_service" do
+        let(:url) { 'http://localhost' }
+        subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
+
+        it "checks and raises an error" do
+          expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+            with(provider_name, url, pact_specification_version: nil, find_available_port: true).
+            and_return(nil)
+          expect { subject }.to raise_error(/pact-mock_service.+does not support/)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/pact/consumer/configuration_spec.rb
+++ b/spec/lib/pact/consumer/configuration_spec.rb
@@ -6,9 +6,10 @@ module Pact::Consumer::Configuration
    describe MockService do
 
       let(:world) { Pact::Consumer::World.new }
+      let(:port_number) { 1234 }
       before do
          Pact.clear_configuration
-         allow(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for)
+         allow(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).and_return(port_number)
          allow(Pact).to receive(:consumer_world).and_return(world)
       end
 
@@ -16,7 +17,7 @@ module Pact::Consumer::Configuration
          let(:consumer_name) {'consumer'}
          subject {
             MockService.build :mock_service, consumer_name, provider_name do
-               port 1234
+               port port_number
                standalone true
                verify true
             end
@@ -24,11 +25,11 @@ module Pact::Consumer::Configuration
 
          let(:provider_name) { 'Mock Provider' }
          let(:consumer_contract_builder) { instance_double('Pact::Consumer::ConsumerContractBuilder') }
-         let(:url) { "http://localhost:1234" }
+         let(:url) { "http://localhost:#{port_number}" }
 
          it "adds a verification to the Pact configuration" do
             allow(Pact::Consumer::ConsumerContractBuilder).to receive(:new).and_return(consumer_contract_builder)
-            subject.finalize
+            subject
             expect(consumer_contract_builder).to receive(:verify)
             Pact.configuration.provider_verifications.first.call
          end
@@ -36,22 +37,48 @@ module Pact::Consumer::Configuration
          context "when standalone" do
             it "does not register the app with the AppManager" do
                expect(Pact::MockService::AppManager.instance).to_not receive(:register_mock_service_for)
-               subject.finalize
+               subject
             end
          end
          context "when not standalone" do
             subject {
                MockService.build :mock_service, consumer_name, provider_name do
-                  port 1234
+                  port port_number
                   standalone false
                   verify true
                   pact_specification_version '1'
                end
             }
             it "registers the app with the AppManager" do
-               expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).with(provider_name, url, pact_specification_version: '1')
-               subject.finalize
+               expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+                 with(provider_name, url, pact_specification_version: '1', find_available_port: false).
+                 and_return(port_number)
+               subject
             end
+         end
+
+         context "without port specification" do
+           let(:url) { 'http://localhost' }
+           subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
+
+           it "registers the app with the AppManager with find_available_port option" do
+             expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+               with(provider_name, url, pact_specification_version: nil, find_available_port: true).
+               and_return(port_number)
+             subject
+           end
+         end
+
+         context "without port specification and old pact-mock_service" do
+           let(:url) { 'http://localhost' }
+           subject { MockService.build(:mock_service, consumer_name, provider_name) {} }
+
+           it "checks and raises an error" do
+             expect(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).
+               with(provider_name, url, pact_specification_version: nil, find_available_port: true).
+               and_return(nil)
+             expect { subject }.to raise_error(/pact-mock_service.+does not support/)
+           end
          end
       end
    end


### PR DESCRIPTION
By https://github.com/bethesque/pact-mock_service/pull/43,
pact-mock_service can find and use available port on machine automatically,
we can configure Pact's mock service without port configuration, and it should
mean the mock service obtains available port automatically.

~~~Feature work: Now we can define mock service without any configuration
but still have to call `mock_service` DSL method with empty block:~~~

```ruby
    Pact.service_consumer 'ConsumerApp' do
      has_pact_with 'ProviderApp' do
        mock_service(:provider_app) {}
      end
    end
```

***[update]*** This feature work will be resolved by https://github.com/bethesque/pact-support/pull/20.