### PR TITLE
Randomise contract interactions

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -13,9 +13,11 @@
 * [doc_dir](#doc_dir)
 * [doc_generator](#doc_generator)
 * [pactfile_write_mode](#pactfile_write_mode)
+* [pactfile_write_order](#pactfile_write_order)
 
 #### Provider only configuration options
 * [include](#include)
+* [interactions_replay_order](#interactions_replay_order)
 
 ## Consumer and Provider
 
@@ -150,6 +152,19 @@ Options: `:overwrite`, `:update`, `:smart`, `:none`
 
 By default, the pact file will be overwritten (started from scratch) every time any rspec runs any spec using pacts. This means that if there are interactions that haven't been executed in the most recent rspec run, they are effectively removed from the pact file. If you have long running pact specs (e.g. they are generated using the browser with Capybara) and you are developing both consumer and provider in parallel, or trying to fix a broken interaction, it can be tedious to run all the specs at once. In this scenario, you can set the pactfile_write_mode to :update. This will keep all existing interactions, and update only the changed ones, identified by description and provider state. The down side of this is that if either of those fields change, the old interactions will not be removed from the pact file. As a middle path, you can set pactfile_write_mode to :smart. This will use :overwrite mode when running rake (as determined by a call to system using 'ps') and :update when running an individual spec. :none will not generate any pact files (with pact-mock_service >= 0.8.1).
 
+### pactfile_write_order
+
+Default value: `:chronological`
+Options: `:chronological`, `:alphabetical`
+
+By default, interactions within the pact file will be ordered in chronological order. As a result of this your pact file might be different with each rspec run.
+
+```ruby
+Pact.configure do | config |
+  config.pactfile_write_order = :alphabetical
+end
+```
+
 ## Provider
 
 Pact uses RSpec and Rack::Test to create dynamic specs based on the pact files. RSpec configuration can be used to modify test behaviour if there is not an appropriate Pact feature. If you wish to use the same spec_helper.rb file as your unit tests, require it in the pact_helper.rb, but remember that the RSpec configurations for your unit tests may or may not be what you want for your pact verification tests.
@@ -163,4 +178,17 @@ end
 ```
 
 To make modules available in the provider state set_up and tear_down blocks, include them in the configuration as shown below. One common use of this to include factory methods for setting up data so that the provider states file doesn't get too bloated.
+
+### interactions_replay_order
+
+Default value: `:recorder`
+Options: `:recorder`, `:random`
+
+Replays interactions in a specific order. In combination with pactfile_write_order will allow you to have a consistent pact contract replayed in random order.  
+
+```ruby
+Pact.configure do | config |
+  config.interactions_replay_order = :random
+end
+```
 

--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'pact/consumer/configuration'
+require 'pact/provider/configuration'
 
 module Pact
   class CLI < Thor
@@ -10,6 +11,9 @@ module Pact
     method_option :pact_broker_username, aliases: "-u", desc: "Pact broker user name"
     method_option :pact_broker_password, aliases: "-w", desc: "Pact broker password"
     method_option :backtrace, aliases: "-b", desc: "Show full backtrace", :default => false, :type => :boolean
+    method_option :interactions_replay_order, aliases: "-o",
+                  desc: "Interactions replay order: randomised or recorded (default)",
+                  default: Pact.configuration.interactions_replay_order
     method_option :description, aliases: "-d", desc: "Interaction description filter"
     method_option :provider_state, aliases: "-s", desc: "Provider state filter"
 

--- a/lib/pact/consumer/configuration/configuration_extensions.rb
+++ b/lib/pact/consumer/configuration/configuration_extensions.rb
@@ -70,6 +70,14 @@ module Pact
           @pactfile_write_mode = pactfile_write_mode
         end
 
+        def pactfile_write_order
+          @pactfile_write_order ||= :chronological #or :alphabetical
+        end
+
+        def pactfile_write_order= pactfile_write_order
+          @pactfile_write_order = pactfile_write_order.to_sym
+        end
+
         private
 
         #Would love a better way of determining this! It sure won't work on windows.

--- a/lib/pact/provider/configuration/configuration_extension.rb
+++ b/lib/pact/provider/configuration/configuration_extension.rb
@@ -29,6 +29,14 @@ module Pact
           @config_ru_path = config_ru_path
         end
 
+        def interactions_replay_order
+          @interactions_replay_order ||= :recorder #or :randomised
+        end
+
+        def interactions_replay_order= interactions_replay_order
+          @interactions_replay_order = interactions_replay_order.to_sym
+        end
+
         def include mod
           Pact::Provider::State::ProviderStateConfiguredModules.instance_eval do
             include mod

--- a/lib/pact/provider/pact_spec_runner.rb
+++ b/lib/pact/provider/pact_spec_runner.rb
@@ -121,8 +121,16 @@ module Pact
           options = {
             criteria: @options[:criteria]
           }
-          honour_pactfile pact_source.uri, pact_source.pact_json, options
+          honour_pactfile pact_source.uri, ordered_pact_json(pact_source.pact_json), options
         end
+      end
+
+      def ordered_pact_json(pact_json)
+        return pact_json if Pact.configuration.interactions_replay_order == :recorded
+
+        consumer_contract = JSON.parse(pact_json)
+        consumer_contract["interactions"] = consumer_contract["interactions"].shuffle
+        consumer_contract.to_json
       end
 
       def class_exists? name

--- a/lib/pact/version.rb
+++ b/lib/pact/version.rb
@@ -1,3 +1,3 @@
 module Pact
-  VERSION = "1.9.1"
+  VERSION = "1.9.2"
 end

--- a/pact.gemspec
+++ b/pact.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
 
   gem.add_runtime_dependency 'pact-support', '~> 0.5.7'
-  gem.add_runtime_dependency 'pact-mock_service', '~> 0.7'
+  gem.add_runtime_dependency 'pact-mock_service', '~> 0.8'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 1.18.0'

--- a/spec/lib/pact/provider/pact_spec_runner_spec.rb
+++ b/spec/lib/pact/provider/pact_spec_runner_spec.rb
@@ -1,0 +1,87 @@
+require 'pact/provider/pact_spec_runner'
+
+describe Pact::Provider::PactSpecRunner do
+  let(:options) { {provider: double(:provider)} }
+  let(:pact_url) { double(:pact_url, uri: 'uri', options: {}) }
+  let(:pact_urls) { [pact_url] }
+  subject { described_class.new(pact_urls, options) }
+
+  let(:interactions) do
+    [{
+       "description"    => "Description 1",
+       "provider_state" => "there is an alligator named Mary",
+       "request"        => {},
+       "response"       => {
+         "status" => 200,
+       }
+     }, {
+       "description"    => "Description 2",
+       "provider_state" => "there is not an alligator named Mary",
+       "request"        => {},
+       "response"       => {
+         "status" => 200,
+       }
+     }, {
+       "description"    => "Description 1",
+       "provider_state" => "an error occurs retrieving an alligator",
+       "request"        => {},
+       "response"       => {
+         "status" => 500,
+       }
+     }]
+  end
+
+  let(:pact_source) do
+    double(:pact_source, uri: 'uri', pact_json: {"interactions" => interactions}.to_json)
+  end
+
+  describe '#run' do
+
+    before do
+      Pact.configuration.interactions_replay_order = interactions_replay_order
+      Pact.service_provider "Fred" do
+        app { "An app" }
+      end
+      allow(subject).to receive(:configure_rspec)
+      allow(subject).to receive(:run_specs)
+
+      expect(PactBroker::Provider::PactSource).to receive(:new).with(pact_url).and_return(pact_source)
+    end
+
+    context 'with multiple interactions' do
+      let(:interactions_replay_order) { :recorded }
+
+      it 'matches the original consumer interactions' do
+        expect_any_instance_of(Array).to_not receive(:shuffle).and_call_original
+
+        expect(subject).to receive(:honour_pactfile) do |_uri, pact_json, _options|
+          consumer_contract = JSON.parse(pact_json)
+          expect(consumer_contract["interactions"]).to eq(interactions)
+        end
+
+        subject.run
+      end
+
+      context 'and interactions_replay_order option set to random' do
+        let(:interactions_replay_order) { :random }
+
+        it 'randomised interactions within consumer contract' do
+          allow(subject).to receive(:honour_pactfile).and_return([])
+          expect_any_instance_of(Array).to receive(:shuffle).and_call_original
+
+          subject.run
+        end
+
+        it 'does not change consumer interactions' do
+          expect(subject).to receive(:honour_pactfile) do |_uri, pact_json, _options|
+            consumer_contract = JSON.parse(pact_json)
+            expect(consumer_contract["interactions"]).to match_array(interactions)
+          end
+
+          subject.run
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Add ability to configure interactions replay order. Default value: 'randomised'
- [ ] dependency: https://github.com/bethesque/pact-mock_service/pull/46