### PR TITLE
remove duplicated `--backtrace` option

### DIFF
--- a/lib/pact/tasks/task_helper.rb
+++ b/lib/pact/tasks/task_helper.rb
@@ -28,7 +28,6 @@ module Pact
       command_parts << "--pact-broker-username" << ENV['PACT_BROKER_USERNAME'] if ENV['PACT_BROKER_USERNAME']
       command_parts << "--pact-broker-password" << ENV['PACT_BROKER_PASSWORD'] if ENV['PACT_BROKER_PASSWORD']
       command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
-      command_parts << "--backtrace" if ENV['BACKTRACE'] == 'true'
       command_parts << "--description #{Shellwords.escape(ENV['PACT_DESCRIPTION'])}" if ENV['PACT_DESCRIPTION']
       command_parts << "--provider-state #{Shellwords.escape(ENV['PACT_PROVIDER_STATE'])}" if ENV['PACT_PROVIDER_STATE']
       command_parts.flatten.join(" ")


### PR DESCRIPTION
`--backtrace` option appears twice.

```
$ rake pact:verify BACKTRACE=true
SPEC_OPTS='' ruby -S pact verify --pact-helper /path/to/pact_helper.rb --backtrace --backtrace
```
