### PR TITLE
Fix Encoding::CompatibilityError in markdown renderer

### DIFF
--- a/lib/pact/doc/markdown/interaction_renderer.rb
+++ b/lib/pact/doc/markdown/interaction_renderer.rb
@@ -25,8 +25,12 @@ module Pact
           ERB.new(template_string(template_file)).result(binding)
         end
 
+        # The template file is written with only ASCII range characters, so we
+        # can read as UTF-8. But rendered strings must have same encoding as
+        # script encoding because it will joined to strings which are produced by
+        # string literal.
         def template_string(template_file)
-          File.read( template_contents(template_file) )
+          File.read(template_contents(template_file), external_encoding: Encoding::UTF_8).force_encoding(__ENCODING__)
         end
 
         def template_contents(template_file)

--- a/spec/lib/pact/doc/markdown/consumer_contract_renderer_spec.rb
+++ b/spec/lib/pact/doc/markdown/consumer_contract_renderer_spec.rb
@@ -9,7 +9,7 @@ module Pact
         subject { ConsumerContractRenderer.new(consumer_contract) }
         let(:consumer_contract) { Pact::ConsumerContract.from_uri './spec/support/markdown_pact.json' }
 
-        let(:expected_output) { File.read("./spec/support/generated_markdown.md") }
+        let(:expected_output) { File.read("./spec/support/generated_markdown.md", external_encoding: Encoding::UTF_8) }
 
         describe "#call" do
 
@@ -19,6 +19,19 @@ module Pact
             it "escapes the markdown characters" do
               expect(subject.call).to include '### A pact between Some\*Consumer\*App and Some\_Provider\_App'
               expect(subject.call).to include '#### Requests from Some\*Consumer\*App to Some\_Provider\_App'
+            end
+          end
+
+          context "with ruby's default external encoding is not UTF-8" do
+            around do |example|
+              back = nil
+              WarningSilencer.enable { back, Encoding.default_external = Encoding.default_external, Encoding::ASCII_8BIT }
+              example.run
+              WarningSilencer.enable { Encoding.default_external = back }
+            end
+
+            it "renders the interactions" do
+              expect(subject.call).to eq(expected_output)
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'pact/provider/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
 require './spec/support/active_support_if_configured'
+require './spec/support/warning_silencer'
 
 RSpec.configure do | config |
   config.include(FakeFS::SpecHelpers, :fakefs => true)

--- a/spec/support/generated_markdown.md
+++ b/spec/support/generated_markdown.md
@@ -2,14 +2,14 @@
 
 #### Requests from Some Consumer to Some Provider
 
-* [A request for alligators](#a_request_for_alligators_given_alligators_exist) given alligators exist
+* [A request for alligators in Brüssel](#a_request_for_alligators_in_Brüssel_given_alligators_exist) given alligators exist
 
 * [A request for polar bears](#a_request_for_polar_bears)
 
 #### Interactions
 
-<a name="a_request_for_alligators_given_alligators_exist"></a>
-Given **alligators exist**, upon receiving **a request for alligators** from Some Consumer, with
+<a name="a_request_for_alligators_in_Brüssel_given_alligators_exist"></a>
+Given **alligators exist**, upon receiving **a request for alligators in Brüssel** from Some Consumer, with
 ```json
 {
   "method": "get",

--- a/spec/support/markdown_pact.json
+++ b/spec/support/markdown_pact.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a request for alligators",
+      "description": "a request for alligators in Brüssel",
       "provider_state": "alligators exist",
       "request": {
         "method": "get",

--- a/spec/support/warning_silencer.rb
+++ b/spec/support/warning_silencer.rb
@@ -1,0 +1,10 @@
+module WarningSilencer
+  extend self
+
+  def enable
+    old, $VERBOSE = $VERBOSE, nil
+    yield
+  ensure
+    $VERBOSE = old
+  end
+end


### PR DESCRIPTION
I faced Encoding::CompatibilityError recently in pact-broker.

The rendered string will be joined with strings who's encoding will be
script encoding.

ruby's default script encoding is UTF-8. In some environments, ruby's
default external encoding will be ASCII-8BIT. It depends system
configuration which we, library developers, can't handle. In that case
Pact::Doc::Markdown::ConsumerContractRenderer#call trys to join UTF-8
strings with non UTF-8 string. It raises Encoding::CompatibilityError.

(below pry session shows encoding difference and error)

    pry(#<Pact::Doc::Markdown::ConsumerContractRenderer>)> [title, summaries_title, summaries.join, interactions_title, full_interactions.join].map {|e| e.encoding }
    => [#<Encoding:UTF-8>, #<Encoding:UTF-8>, #<Encoding:UTF-8>, #<Encoding:UTF-8>, #<Encoding:US-ASCII>]

    pry(#<Pact::Doc::Markdown::ConsumerContractRenderer>)> title + summaries_title + summaries.join + interactions_title + full_interactions.join
    Encoding::CompatibilityError: incompatible character encodings: UTF-8 and US-ASCII from (pry):11:in `call'

To prevent this error, we have to read and translate the template string with script encoding.
The template renderer (ERB here) will respect encoding of template
string.