### PR TITLE
Raise an error when the interaction is invalid

### DIFF
--- a/lib/pact/consumer/consumer_contract_builder.rb
+++ b/lib/pact/consumer/consumer_contract_builder.rb
@@ -51,7 +51,9 @@ module Pact
         mock_service_client.wait_for_interactions wait_max_seconds, poll_interval
       end
 
+      # @raise Pact::InvalidInteractionError
       def handle_interaction_fully_defined interaction
+        interaction.validate! if interaction.respond_to?(:validate!)
         mock_service_client.add_expected_interaction interaction #TODO: What will happen if duplicate added?
         self.interaction_builder = nil
       end
@@ -65,7 +67,7 @@ module Pact
         @interaction_builder ||=
         begin
           interaction_builder = InteractionBuilder.new do | interaction |
-            self.handle_interaction_fully_defined(interaction)
+            handle_interaction_fully_defined(interaction)
           end
           interaction_builder
         end

--- a/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
+++ b/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
@@ -19,8 +19,7 @@ module Pact
           :pact_dir => pact_dir)
       end
 
-      describe "handle_interaction_fully_defined" do
-
+      describe "#handle_interaction_fully_defined" do
 
         let(:interaction_hash) {
           {
@@ -56,6 +55,20 @@ module Pact
           expect(subject).to receive(:interaction_builder=).with(nil)
           subject.handle_interaction_fully_defined interaction
         end
+
+        if defined?(Pact::InvalidInteractionError)
+          context "when interaction is not defined correctly" do
+            before { interaction_hash.delete(:description) }
+
+            it "raises Pact::InvalidInteractionError" do
+              expect {
+                subject.handle_interaction_fully_defined(interaction)
+              }.to(raise_error(Pact::InvalidInteractionError) do |e|
+                expect(e.message).to include("description")
+              end)
+            end
+          end
+        end
       end
 
       describe "#mock_service_base_url" do
@@ -73,7 +86,7 @@ module Pact
       	end
       end
 
-      describe "write_pact" do
+      describe "#write_pact" do
 
         let(:body) do
           {


### PR DESCRIPTION
Check the interaction is defined correctly here. If the interaction is
not defined correctly, that can cause errors in pact verification in
Provider test. For example, "undefined method `capitalize' for
nil:NilClass" at `#interaction_description_for_rerun_command`.

I sent follow up PR to pact-support repository: https://github.com/bethesque/pact-support/pull/24