### PR TITLE
Fix bug in default interactions replay order

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -181,8 +181,8 @@ To make modules available in the provider state set_up and tear_down blocks, inc
 
 ### interactions_replay_order
 
-Default value: `:recorder`
-Options: `:recorder`, `:random`
+Default value: `:recorded`
+Options: `:recorded`, `:random`
 
 Replays interactions in a specific order. In combination with pactfile_write_order will allow you to have a consistent pact contract replayed in random order.  
 

--- a/lib/pact/provider/configuration/configuration_extension.rb
+++ b/lib/pact/provider/configuration/configuration_extension.rb
@@ -30,7 +30,7 @@ module Pact
         end
 
         def interactions_replay_order
-          @interactions_replay_order ||= :recorder #or :randomised
+          @interactions_replay_order ||= :recorded #or :random
         end
 
         def interactions_replay_order= interactions_replay_order

--- a/spec/lib/pact/provider/configuration/configuration_extension_spec.rb
+++ b/spec/lib/pact/provider/configuration/configuration_extension_spec.rb
@@ -11,6 +11,10 @@ module Pact
 
         subject { Object.new.extend(ConfigurationExtension) }
 
+        it 'replays interactions in the recorded order by default' do
+          expect(subject.interactions_replay_order).to eq :recorded
+        end
+
       end
     end
   end


### PR DESCRIPTION
Fix bug in default interactions replay order

* Fix `:recorer` vs `:recorded` incosistency in favour of `:recorded`
  with reliance on the spec
* Otherwise default was actually non-expected `:random` because of
  ```
    def ordered_pact_json(pact_json)
      return pact_json if Pact.configuration.interactions_replay_order == :recorded

      consumer_contract = JSON.parse(pact_json)
      consumer_contract["interactions"] = consumer_contract["interactions"].shuffle
      consumer_contract.to_json
    end
  ```