### PR TITLE
move awesome_print dependency to development

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'randexp', '~> 0.1.7'
   gem.add_runtime_dependency 'rspec', '>=2.14'
   gem.add_runtime_dependency 'rack-test', '~> 0.6.2'
-  gem.add_runtime_dependency 'awesome_print', '~> 1.1'
   gem.add_runtime_dependency 'thor'
   gem.add_runtime_dependency 'json' #Not locking down a version because buncher gem requires 1.6, while other projects use 1.7.
   gem.add_runtime_dependency 'webrick'
@@ -32,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact-support', '~> 0.5.7'
   gem.add_runtime_dependency 'pact-mock_service', '~> 0.8'
 
+  gem.add_development_dependency 'awesome_print', '~> 1.1'
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 1.18.0'
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
This gem shouldn't be included as a production dependency.