### PR TITLE
Code style clean up for specs.

### DIFF
--- a/lib/pact/provider/rspec.rb
+++ b/lib/pact/provider/rspec.rb
@@ -23,13 +23,13 @@ module Pact
           puts "Reading pact at #{pact_uri}"
           puts "Filtering interactions by: #{options[:criteria]}" if options[:criteria] && options[:criteria].any?
           consumer_contract = Pact::ConsumerContract.from_json(pact_json)
-          ::RSpec.describe "Verifying a pact between #{consumer_contract.consumer.name} and #{consumer_contract.provider.name}", :pactfile_uri => pact_uri do
+          ::RSpec.describe "Verifying a pact between #{consumer_contract.consumer.name} and #{consumer_contract.provider.name}", pactfile_uri: pact_uri do
             honour_consumer_contract consumer_contract, options.merge(pact_json: pact_json)
           end
         end
 
         def honour_consumer_contract consumer_contract, options = {}
-          describe_consumer_contract consumer_contract, options.merge(:consumer => consumer_contract.consumer.name)
+          describe_consumer_contract consumer_contract, options.merge(consumer: consumer_contract.consumer.name)
         end
 
         private
@@ -61,10 +61,10 @@ module Pact
         def describe_interaction interaction, options
 
           metadata = {
-            :pact => :verify,
-            :pact_interaction => interaction,
-            :pact_interaction_example_description => interaction_description_for_rerun_command(interaction),
-            :pact_json => options[:pact_json]
+            pact: :verify,
+            pact_interaction: interaction,
+            pact_interaction_example_description: interaction_description_for_rerun_command(interaction),
+            pact_json: options[:pact_json]
           }
 
           describe description_for(interaction), metadata do

--- a/spec/integration/consumer_with_params_hash_spec.rb
+++ b/spec/integration/consumer_with_params_hash_spec.rb
@@ -10,10 +10,11 @@ describe "A service consumer side of a pact", :pact => true  do
   # Helper to make Faraday requests.
   # Faraday::FlatParamsEncoder may only be needed with our current version of Faraday 0.9
   # and ensures that when there are multiple parameters of the same name, they are encoded properly. e.g. colour=blue&colour=green
-  def faraday_mallory(base_url,params, headers = {})
-    (Faraday.new base_url, :request => {
-       :params_encoder => Faraday::FlatParamsEncoder,
-    }).get '/mallory', params, {'Accept' => 'application/json'}.merge(headers)
+  def faraday_mallory(base_url, params, headers = {})
+    Faraday.new(
+      base_url,
+      request: { params_encoder: Faraday::FlatParamsEncoder }
+    ).get '/mallory', params, { 'Accept' => 'application/json' }.merge(headers)
   end
 
   let(:body) { 'That is some good Mallory.' }
@@ -35,24 +36,24 @@ describe "A service consumer side of a pact", :pact => true  do
 
     before do
 
-      zebra_service2.
-        given(:the_zebras_are_here).
-        upon_receiving("a retrieve Mallory request").with({
+      zebra_service2
+        .given(:the_zebras_are_here)
+        .upon_receiving("a retrieve Mallory request")
+        .with(
           method: :get,
           path: '/mallory',
-          headers: {'Accept' => 'application/json'},
-          query: {colour: 'brown', size: ['small', 'large']}
-        }).
-        will_respond_with({
+          headers: { 'Accept' => 'application/json' },
+          query: { colour: 'brown', size: ['small', 'large'] }
+        )
+        .will_respond_with(
           status: 200,
           headers: { 'Content-Type' => 'application/json' },
           body: term(/Mallory/, body)
-      })
-
+        )
     end
 
     it "matches when all instances are provided" do
-      response= faraday_mallory(zebra_service2.mock_service_base_url, { size: ['small','large'], colour: 'brown'})
+      response = faraday_mallory(zebra_service2.mock_service_base_url, size: ['small', 'large'], colour: 'brown')
       expect(response.body).to eq body
 
       interactions = Pact::ConsumerContract.from_json(zebra_service2.write_pact).interactions
@@ -60,17 +61,17 @@ describe "A service consumer side of a pact", :pact => true  do
     end
 
     it "does not match when only the first instance is provided" do
-      response = Faraday.get(zebra_service2.mock_service_base_url + "/mallory?colour=brown&size=small", nil, {'Accept' => 'application/json'})
+      response = Faraday.get(zebra_service2.mock_service_base_url + "/mallory?colour=brown&size=small", nil, 'Accept' => 'application/json')
       expect(response.body).not_to eq body
     end
 
     it "does not match when only the last instance is provided" do
-      response = Faraday.get(zebra_service2.mock_service_base_url + "/mallory?colour=brown&size=large", nil, {'Accept' => 'application/json'})
+      response = Faraday.get(zebra_service2.mock_service_base_url + "/mallory?colour=brown&size=large", nil, 'Accept' => 'application/json')
       expect(response.body).not_to eq body
     end
 
     it "does not match when they are out of order" do
-      response= faraday_mallory(zebra_service2.mock_service_base_url, { size: ['large','small'], colour: 'brown'})
+      response = faraday_mallory(zebra_service2.mock_service_base_url, size: ['large', 'small'], colour: 'brown')
       expect(response.body).not_to eq body
     end
   end
@@ -96,8 +97,8 @@ describe "A service consumer side of a pact", :pact => true  do
         with({
            method: :get,
            path: '/mallory',
-           headers: {'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'},
-           query: { size: ['small',term(/med.*/, 'medium'),'large'], colour: 'brown', weight: '5'}
+           headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' },
+           query: { size: ['small', term(/med.*/, 'medium'), 'large'], colour: 'brown', weight: '5' }
         }).
         will_respond_with({
           status: 200,
@@ -109,8 +110,8 @@ describe "A service consumer side of a pact", :pact => true  do
     let(:response) do
       faraday_mallory(
         zebra_service.mock_service_base_url,
-        { weight: 5, size: ['small','medium','large'], colour: 'brown'},
-        {'Content-Type' => 'application/x-www-form-urlencoded'}
+        { weight: 5, size: ['small','medium','large'], colour: 'brown' },
+        { 'Content-Type' => 'application/x-www-form-urlencoded' }
       )
     end
 

--- a/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
+++ b/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
@@ -12,11 +12,11 @@ module Pact
 
       subject do
         Pact::Consumer::ConsumerContractBuilder.new(
-          :consumer_name => consumer_name,
-          :provider_name => provider_name,
-          :pactfile_write_mode => :overwrite,
-          :port => 2222,
-          :pact_dir => pact_dir)
+          consumer_name: consumer_name,
+          provider_name: provider_name,
+          pactfile_write_mode: :overwrite,
+          port: 2222,
+          pact_dir: pact_dir)
       end
 
       describe "#handle_interaction_fully_defined" do
@@ -64,13 +64,15 @@ module Pact
 
       describe "#mock_service_base_url" do
 
-      	subject {
+      	subject do
       		ConsumerContractBuilder.new(
-      			:pactfile_write_mode => :overwrite,
-            :pact_dir => './spec/pacts',
-            :consumer_name => consumer_name,
-            :provider_name => provider_name,
-        		:port => 1234) }
+      			pactfile_write_mode: :overwrite,
+            pact_dir: './spec/pacts',
+            consumer_name: consumer_name,
+            provider_name: provider_name,
+        		port: 1234
+          )
+        end
 
       	it "returns the mock service base URL" do
       		expect(subject.mock_service_base_url).to eq("http://localhost:1234")

--- a/spec/lib/pact/provider/configuration/pact_verification_spec.rb
+++ b/spec/lib/pact/provider/configuration/pact_verification_spec.rb
@@ -7,7 +7,7 @@ module Pact
       describe PactVerification do
 
         describe 'create_verification' do
-          let(:url) {'http://some/uri'}
+          let(:url) { 'http://some/uri' }
           let(:pact_repository_uri_options) do
             {
               username: 'pact_broker_username',
@@ -15,8 +15,9 @@ module Pact
             }
           end
           let(:consumer_name) {'some consumer'}
-          let(:ref) {:prod}
-          let(:options) { {:ref => :prod} }
+          let(:ref) { :prod }
+          let(:options) { { ref: :prod } }
+
           context "with valid values" do
             subject do
               uri = url
@@ -40,7 +41,7 @@ module Pact
             end
 
             it "raises a validation error" do
-              expect{ subject }.to raise_error /Please provide a pact_uri/
+              expect { subject }.to raise_error /Please provide a pact_uri/
             end
           end
         end

--- a/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
+++ b/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
@@ -18,8 +18,9 @@ module Pact
                 app 'blah'
               end
             end
+
             it "raises an error" do
-              expect{ subject }.to raise_error /wrong number of arguments/
+              expect { subject }.to raise_error /wrong number of arguments/
             end
           end
 
@@ -32,18 +33,21 @@ module Pact
                 app { Object.new }
               end
             end
+
             it "raises an error" do
-              expect{ subject.send(:validate)}.to raise_error("Please provide a name for the Provider")
+              expect { subject.send(:validate) }.to raise_error("Please provide a name for the Provider")
             end
           end
+
           context "when nil name is provided" do
             subject do
               ServiceProviderDSL.new nil do
                 app { Object.new }
               end
             end
+
             it "raises an error" do
-              expect{ subject.send(:validate)}.to raise_error("Please provide a name for the Provider")
+              expect { subject.send(:validate) }.to raise_error("Please provide a name for the Provider")
             end
           end
         end
@@ -52,7 +56,7 @@ module Pact
           before do
             Pact.clear_provider_world
           end
-          let(:pact_url) { 'blah'}
+          let(:pact_url) { 'blah' }
 
           context "with no optional params" do
             subject do
@@ -63,10 +67,12 @@ module Pact
                 end
               end
             end
+
             it 'adds a verification to the Pact.provider_world' do
               subject
               pact_uri = Pact::Provider::PactURI.new(pact_url)
-              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', pact_uri, :head))
+              expect(Pact.provider_world.pact_verifications.first)
+                .to eq(Pact::Provider::PactVerification.new('some-consumer', pact_uri, :head))
             end
           end
 
@@ -80,15 +86,17 @@ module Pact
             subject do
               ServiceProviderDSL.build 'some-provider' do
                 app {}
-                honours_pact_with 'some-consumer', :ref => :prod do
+                honours_pact_with 'some-consumer', ref: :prod do
                   pact_uri pact_url, pact_uri_options
                 end
               end
             end
+
             it 'adds a verification to the Pact.provider_world' do
               subject
               pact_uri = Pact::Provider::PactURI.new(pact_url, pact_uri_options)
-              expect(Pact.provider_world.pact_verifications.first).to eq(Pact::Provider::PactVerification.new('some-consumer', pact_uri , :prod))
+              expect(Pact.provider_world.pact_verifications.first)
+                .to eq(Pact::Provider::PactVerification.new('some-consumer', pact_uri , :prod))
             end
 
           end
@@ -105,7 +113,8 @@ module Pact
             end
 
             it "raises an error with some helpful text" do
-              expect{ ServiceProviderDSL::CONFIG_RU_APP.call }.to raise_error /Could not find config\.ru file.*#{Regexp.escape(path_that_does_not_exist)}/
+              expect { ServiceProviderDSL::CONFIG_RU_APP.call }
+                .to raise_error /Could not find config\.ru file.*#{Regexp.escape(path_that_does_not_exist)}/
             end
 
           end
@@ -115,4 +124,3 @@ module Pact
     end
   end
 end
-

--- a/spec/lib/pact/provider/help/console_text_spec.rb
+++ b/spec/lib/pact/provider/help/console_text_spec.rb
@@ -8,7 +8,7 @@ module Pact
       describe ConsoleText do
 
         describe ".call" do
-          let(:help_path) { File.join(reports_dir, Write::HELP_FILE_NAME)}
+          let(:help_path) { File.join(reports_dir, Write::HELP_FILE_NAME) }
           let(:reports_dir) { "./tmp/reports/pacts" }
           let(:color) { false }
 

--- a/spec/lib/pact/provider/help/content_spec.rb
+++ b/spec/lib/pact/provider/help/content_spec.rb
@@ -7,8 +7,8 @@ module Pact
 
         describe "#text" do
 
-          let(:pact_1_json) { {some: 'json'}.to_json }
-          let(:pact_2_json) { {some: 'other json'}.to_json }
+          let(:pact_1_json) { { some: 'json'}.to_json }
+          let(:pact_2_json) { { some: 'other json'}.to_json }
           let(:pact_jsons) { [pact_1_json, pact_2_json] }
 
           before do

--- a/spec/lib/pact/provider/help/pact_diff_spec.rb
+++ b/spec/lib/pact/provider/help/pact_diff_spec.rb
@@ -24,8 +24,8 @@ module Pact
         describe ".call" do
 
           before do
-            stub_request(:get, "http://pact-broker/diff").
-              to_return(:status => 200, :body => diff, :headers => {})
+            stub_request(:get, "http://pact-broker/diff")
+              .to_return(status: 200, body: diff, headers: {})
           end
 
           subject { PactDiff.(pact_json) }
@@ -90,6 +90,7 @@ module Pact
               subject
               expect(output).to include("The following changes")
             end
+
             it "returns the diff" do
               subject
               expect(output).to include('some')
@@ -99,8 +100,8 @@ module Pact
 
           context "when the diff resource doesn't exist" do
             before do
-              stub_request(:get, "http://pact-broker/diff").
-                to_return(:status => 404)
+              stub_request(:get, "http://pact-broker/diff")
+                .to_return(status: 404)
             end
 
             it "returns a warning" do
@@ -111,9 +112,8 @@ module Pact
 
           context "when a redirect is received" do
             before do
-              stub_request(:get, "http://pact-broker/diff").
-                to_return(:status => 301, :body => diff, :headers => {})
-
+              stub_request(:get, "http://pact-broker/diff")
+                .to_return(status: 301, body: diff, headers: {})
             end
 
             xit "follows the redirect" do

--- a/spec/lib/pact/provider/matchers/messages_spec.rb
+++ b/spec/lib/pact/provider/matchers/messages_spec.rb
@@ -41,7 +41,7 @@ module Pact
 
         context "when the actual is not a string" do
 
-          let(:actual) { {the: "actual"} }
+          let(:actual) { { the: "actual" } }
 
           it "includes the actual as json" do
             expect(subject).to include(actual.to_json)

--- a/spec/lib/pact/provider/pact_helper_locator_spec.rb
+++ b/spec/lib/pact/provider/pact_helper_locator_spec.rb
@@ -25,7 +25,7 @@ module Pact::Provider
         ''
       ]
 
-      PACT_HELPER_FILE_DIRS.each do | dir |
+      PACT_HELPER_FILE_DIRS.each do |dir|
         context "the pact_helper is stored in #{dir}" do
           it "finds the pact_helper" do
             make_pactfile dir

--- a/spec/lib/pact/provider/pact_uri_spec.rb
+++ b/spec/lib/pact/provider/pact_uri_spec.rb
@@ -1,10 +1,10 @@
 describe Pact::Provider::PactURI do
-  let(:uri) { 'http://uri'}
-  let(:username) { 'pact'}
-  let(:options) { {username: username}}
-  let(:pact_uri) { Pact::Provider::PactURI.new(uri, options)}
-  describe '#==' do
+  let(:uri) { 'http://uri' }
+  let(:username) { 'pact' }
+  let(:options) { { username: username } }
+  let(:pact_uri) { Pact::Provider::PactURI.new(uri, options) }
 
+  describe '#==' do
     it 'should return false if object is not PactURI' do
       expect(pact_uri == Object.new).to be false
     end
@@ -14,7 +14,7 @@ describe Pact::Provider::PactURI do
     end
 
     it 'should return false if uri options are not equal' do
-      expect(pact_uri == Pact::Provider::PactURI.new(uri, {username: 'wrong user'})).to be false
+      expect(pact_uri == Pact::Provider::PactURI.new(uri, username: 'wrong user')).to be false
     end
 
     it 'should return true if uri and options are equal' do
@@ -25,7 +25,8 @@ describe Pact::Provider::PactURI do
   describe '#to_s' do
     context 'with userinfo provided' do
       let(:password) { 'my_password' }
-      let(:options) { {username: username, password: password}}
+      let(:options) { { username: username, password: password } }
+
       it 'should include user name and password' do
         expect(pact_uri.to_s).to eq('http://pact:*****@uri')
       end
@@ -33,6 +34,7 @@ describe Pact::Provider::PactURI do
 
     context 'without userinfo' do
       let(:options) { {} }
+
       it 'should return original uri string' do
         expect(pact_uri.to_s).to eq(uri)
       end

--- a/spec/lib/pact/provider/print_missing_provider_states_spec.rb
+++ b/spec/lib/pact/provider/print_missing_provider_states_spec.rb
@@ -6,9 +6,11 @@ module Pact
     describe PrintMissingProviderStates do
 
       describe "text" do
-        let(:missing_provider_states) { {'Consumer 1' => ['state1','state2'], 'Consumer 2' => ['state3']} }
-        let(:expected_output) { File.read("./spec/support/missing_provider_states_output.txt")}
+        let(:missing_provider_states) { { 'Consumer 1' => ['state1', 'state2'], 'Consumer 2' => ['state3'] } }
+        let(:expected_output) { File.read("./spec/support/missing_provider_states_output.txt") }
+
         subject { PrintMissingProviderStates.text missing_provider_states }
+
         it "returns the text" do
           expect(subject).to include expected_output
         end

--- a/spec/lib/pact/provider/request_spec.rb
+++ b/spec/lib/pact/provider/request_spec.rb
@@ -4,23 +4,26 @@ require 'pact/provider/request'
 describe Pact::Provider::Request::Replayable do
 
   let(:path) { '/path?something' }
-  let(:body) { {a: 'body'} }
+  let(:body) { { a: 'body' } }
   let(:headers) { {} }
   let(:expected_request) do
-    instance_double('Pact::Request::Expected',
-      :method => 'post',
-      :full_path => path,
-      :body => body,
-      :headers => headers)
+    instance_double(
+      'Pact::Request::Expected',
+      method: 'post',
+      full_path: path,
+      body: body,
+      headers: headers
+    )
   end
 
-  subject { described_class.new(expected_request)}
+  subject { described_class.new(expected_request) }
 
   describe "method" do
     it 'returns the method' do
       expect(subject.method).to eq 'post'
     end
   end
+
   describe "path" do
     it "returns the full path" do
       expect(subject.path).to eq(path)
@@ -30,30 +33,39 @@ describe Pact::Provider::Request::Replayable do
   describe "body" do
     context "when body is a NullExpectation" do
       let(:body) { Pact::NullExpectation.new }
+
       it "returns an empty string, not sure if it should do this or return nil???" do
         expect(subject.body).to eq ""
       end
     end
+
     context "when body is an empty string" do
       let(:body) { '' }
+
       it "returns an empty string" do
         expect(subject.body).to eq ""
       end
     end
+
     context "when body is a string" do
-      let(:body) { 'a string'}
+      let(:body) { 'a string' }
+
       it "returns the string" do
         expect(subject.body).to eq body
       end
     end
+
     context "when body is a Term" do
       let(:body) { Pact.term(generate: 'a', matcher: /a/) }
+
       it "returns the generated value" do
         expect(subject.body).to eq "a"
       end
     end
+
     context "when body is not a string" do
-      let(:body) { {a: 'body'} }
+      let(:body) { { a: 'body' } }
+
       it "returns the object as a json string" do
         expect(subject.body).to eq body.to_json
       end
@@ -62,14 +74,32 @@ describe Pact::Provider::Request::Replayable do
 
   describe "headers" do
     context "when headers are expected" do
-      let(:headers) { {"Content-Type" => "text/plain", "Content-Length" => "123", "X-Content-Type" => "special", "Access-Control-Request-Method" => "POST"} }
-      let(:expected_headers) { {"CONTENT_TYPE" => "text/plain", "CONTENT_LENGTH" => "123", "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "POST", "HTTP_X_CONTENT_TYPE" => "special"} }
+      let(:headers) do
+        {
+          "Content-Type" => "text/plain",
+          "Content-Length" => "123",
+          "X-Content-Type" => "special",
+          "Access-Control-Request-Method" => "POST"
+        }
+      end
+
+      let(:expected_headers) do
+        {
+          "CONTENT_TYPE" => "text/plain",
+          "CONTENT_LENGTH" => "123",
+          "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "POST",
+          "HTTP_X_CONTENT_TYPE" => "special"
+        }
+      end
+
       it "transforms the headers into Rack format" do
-        expect(subject.headers).to eq( expected_headers )
+        expect(subject.headers).to eq(expected_headers)
       end
     end
+
     context "when headers are not specified" do
       let(:headers) { Pact::NullExpectation.new }
+
       it "returns an empty hash" do
         expect(subject.headers).to eq({})
       end

--- a/spec/lib/pact/provider/rspec_spec.rb
+++ b/spec/lib/pact/provider/rspec_spec.rb
@@ -2,7 +2,6 @@ require 'pact/provider/rspec/matchers'
 require 'pact/shared/json_differ'
 require 'pact/matchers/unix_diff_formatter'
 
-
 describe "the match_term matcher" do
 
   include Pact::RSpec::Matchers
@@ -10,27 +9,33 @@ describe "the match_term matcher" do
   let(:diff_formatter) { Pact::Matchers::UnixDiffFormatter }
 
   it 'does not match a hash to an array' do
-    expect({}).to_not match_term([], with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect({})
+      .to_not match_term([], with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
 
   it 'does not match an array to a hash' do
-    expect([]).to_not match_term({}, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect([])
+      .to_not match_term({}, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
 
   it 'matches regular expressions' do
-    expect('blah').to match_term(/[a-z]*/, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect('blah')
+      .to match_term(/[a-z]*/, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
 
   it 'matches pact terms' do
-    expect('wootle').to match_term Pact.term(generate:'wootle', matcher:/woot../), with: Pact::JsonDiffer, diff_formatter: diff_formatter
+    expect('wootle')
+      .to match_term Pact.term(generate: 'wootle', matcher: /woot../), with: Pact::JsonDiffer, diff_formatter: diff_formatter
   end
 
   it 'matches all elements of arrays' do
-    expect(['one', 'two', ['three']]).to match_term [/one/, 'two', [Pact.term(generate:'three', matcher:/thr../)]], with: Pact::JsonDiffer, diff_formatter: diff_formatter
+    expect(['one', 'two', ['three']])
+      .to match_term [/one/, 'two', [Pact.term(generate: 'three', matcher: /thr../)]], with: Pact::JsonDiffer, diff_formatter: diff_formatter
   end
 
   it 'matches all values of hashes' do
-    expect({1 => 'one', 2 => 2, 3 => 'three'}).to match_term({1 => /one/, 2 => 2, 3 => Pact.term(generate:'three', matcher:/thr../)}, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect({ 1 => 'one', 2 => 2, 3 => 'three' })
+      .to match_term({ 1 => /one/, 2 => 2, 3 => Pact.term(generate: 'three', matcher: /thr../) }, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
 
   it 'matches all other objects using ==' do
@@ -41,7 +46,7 @@ describe "the match_term matcher" do
   # by the provider, but not are not specified in the pact. This means that any hash will match an
   # expected empty hash, because there is currently no way for a consumer to expect an absence of keys.
   it 'is confused by an empty hash' do
-    expect({:hello => 'everyone'}).to match_term({}, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect(hello: 'everyone').to match_term({}, with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
 
   it 'should not be confused by an empty array' do
@@ -49,7 +54,7 @@ describe "the match_term matcher" do
   end
 
   it "should allow matches on an array where each item in the array only contains a subset of the actual" do
-    expect([{name: 'Fred', age: 12}, {name: 'John', age: 13}]).to match_term([{name: 'Fred'}, {name: 'John'}], with: Pact::JsonDiffer, diff_formatter: diff_formatter)
+    expect([{ name: 'Fred', age: 12 }, { name: 'John', age: 13 }])
+      .to match_term([{ name: 'Fred' }, { name: 'John' }], with: Pact::JsonDiffer, diff_formatter: diff_formatter)
   end
-
 end

--- a/spec/lib/pact/provider/state/provider_state_proxy_spec.rb
+++ b/spec/lib/pact/provider/state/provider_state_proxy_spec.rb
@@ -7,8 +7,8 @@ module Pact
 
       let(:provider_state_proxy) { ProviderStateProxy.new }
 
-      let(:options) { { :for => 'some consumer'} }
-      let(:provider_state) { double("provider_state")}
+      let(:options) { { for: 'some consumer' } }
+      let(:provider_state) { double("provider_state") }
 
       describe "get" do
         let(:name) { "some state" }
@@ -35,7 +35,7 @@ module Pact
         context "when the state does not exist" do
 
           let(:provider_state) { nil }
-          let(:expected_missing_provider_states) { {"some consumer" => ["some state"]} }
+          let(:expected_missing_provider_states) { { "some consumer" => ["some state"] } }
 
           it "raises an error" do
             expect { subject }.to raise_error /Could not find.*some state.*consumer.*/
@@ -54,8 +54,6 @@ module Pact
             end
           end
         end
-
-
       end
 
       describe "get_base" do

--- a/spec/lib/pact/provider/state/provider_state_spec.rb
+++ b/spec/lib/pact/provider/state/provider_state_spec.rb
@@ -13,7 +13,6 @@ module Pact
 
       describe 'global ProviderState' do
 
-
         Pact.provider_state :no_alligators do
           set_up do
             MESSAGES << 'set_up'
@@ -26,7 +25,6 @@ module Pact
         Pact.provider_state 'some alligators' do
           no_op
         end
-
 
         subject { ProviderStates.get('no_alligators') }
 
@@ -50,6 +48,7 @@ module Pact
               expect(ProviderStates.get('no_alligators')).to_not be_nil
             end
           end
+
           context 'when the name is a matching string' do
             it 'will return the ProviderState' do
               expect(ProviderStates.get('some alligators')).to_not be_nil
@@ -68,6 +67,7 @@ module Pact
             ProviderStates.get('with_no_op').tear_down
           end
         end
+
         context "when a no_op is defined with a set_up" do
           it "raises an error" do
             expect do
@@ -80,6 +80,7 @@ module Pact
             end
           end
         end
+
         context "when a no_op is defined with a tear_down" do
           it "raises an error" do
             expect do
@@ -94,7 +95,6 @@ module Pact
         end
 
       end
-
 
       describe 'namespaced ProviderStates' do
 
@@ -121,11 +121,11 @@ module Pact
         describe '.get' do
           context 'for a consumer' do
             it 'has a namespaced name' do
-              expect(ProviderStates.get('the weather is sunny', :for => 'a consumer')).to_not be_nil
+              expect(ProviderStates.get('the weather is sunny', for: 'a consumer')).to_not be_nil
             end
 
             it 'falls back to a global state of the same name if one is not found for the specified consumer' do
-              expect(ProviderStates.get('the weather is cloudy', :for => 'a consumer')).to_not be_nil
+              expect(ProviderStates.get('the weather is cloudy', for: 'a consumer')).to_not be_nil
             end
           end
 
@@ -134,7 +134,7 @@ module Pact
         describe 'set_up' do
           context 'for a consumer' do
             it 'runs its own setup' do
-              ProviderStates.get('the weather is sunny', :for => 'a consumer').set_up
+              ProviderStates.get('the weather is sunny', for: 'a consumer').set_up
               expect(NAMESPACED_MESSAGES).to eq ['sunny!']
             end
           end
@@ -150,15 +150,15 @@ module Pact
 
         context "when the base state has been declared" do
           it "creates a base state for the provider" do
-            ProviderStates.get_base(:for => "a consumer with base state").set_up
+            ProviderStates.get_base(for: "a consumer with base state").set_up
             expect(MESSAGES).to eq ["setting up base provider state"]
           end
         end
 
         context "when a base state has not been declared" do
           it "returns a no op state" do
-            ProviderStates.get_base(:for => "a consumer that does not exist").set_up
-            ProviderStates.get_base(:for => "a consumer that does not exist").tear_down
+            ProviderStates.get_base(for: "a consumer that does not exist").set_up
+            ProviderStates.get_base(for: "a consumer that does not exist").tear_down
           end
         end
 
@@ -172,7 +172,7 @@ module Pact
         end
 
         it "creates a base state for the provider" do
-          ProviderStates.get_base(:for => "a consumer with base state with only a tear down").tear_down
+          ProviderStates.get_base(for: "a consumer with base state with only a tear down").tear_down
           expect(MESSAGES).to eq ["tearing down without a set up"]
         end
       end
@@ -210,6 +210,7 @@ module Pact
             end.to raise_error(/Please provide a set_up or tear_down block for provider state \"invalid\"/)
           end
         end
+
         context "when a no_op is defined" do
           it "does not raise an error" do
             expect do

--- a/spec/support/shared_examples_for_request.rb
+++ b/spec/support/shared_examples_for_request.rb
@@ -3,12 +3,14 @@ shared_examples "a request" do
   describe 'matching' do
     let(:expected) do
       Pact::Request::Expected.from_hash(
-        {'method' => 'get', 'path' => 'path', 'query' => /b/}
-        )
+        'method' => 'get', 'path' => 'path', 'query' => /b/
+      )
     end
 
     let(:actual) do
-      Pact::Consumer::Request::Actual.from_hash({'method' => 'get', 'path' => 'path', 'query' => 'blah', 'headers' => {}, 'body' => ''})
+      Pact::Consumer::Request::Actual.from_hash(
+        'method' => 'get', 'path' => 'path', 'query' => 'blah', 'headers' => {}, 'body' => ''
+      )
     end
 
     it "should match" do
@@ -18,25 +20,32 @@ shared_examples "a request" do
 
   describe 'full_path' do
     context "with empty path" do
-      subject { described_class.from_hash({:path => '', :method => 'get', :query => '', :headers => {}}) }
-      it "returns the full path"do
+      subject { described_class.from_hash(path: '', method: 'get', query: '', headers: {}) }
+
+      it "returns the full path" do
         expect(subject.full_path).to eq "/"
       end
     end
+
     context "with a path" do
-      subject { described_class.from_hash({:path => '/path', :method => 'get', :query => '', :headers => {}}) }
-      it "returns the full path"do
+      subject { described_class.from_hash(path: '/path', method: 'get', query: '', headers: {}) }
+
+      it "returns the full path" do
         expect(subject.full_path).to eq "/path"
       end
     end
+
     context "with a path and query" do
-      subject { described_class.from_hash({:path => '/path', :method => 'get', :query => "something", :headers => {}}) }
-      it "returns the full path"do
+      subject { described_class.from_hash(path: '/path', method: 'get', query: "something", headers: {}) }
+
+      it "returns the full path" do
         expect(subject.full_path).to eq "/path?something"
       end
     end
+
     context "with a path and a query that is a Term" do
-      subject { described_class.from_hash({:path => '/path', :method => 'get', :headers => {}, :query => Pact.term(generate: 'a', matcher: /a/)}) }
+      subject { described_class.from_hash(path: '/path', method: 'get', headers: {}, query: Pact.term(generate: 'a', matcher: /a/)) }
+
       it "returns the full path with reified path" do
         expect(subject.full_path).to eq "/path?a"
       end


### PR DESCRIPTION
- Use ruby 2.0 hash syntax
- Remove redundant hash curly braces for params
- Sensible new line and spacing