### PR TITLE
Travis: use jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 - 2.2.4
 - 2.3.1
 - 2.4
-- jruby-9.0.5.0
+- jruby-9.1.13.0
 gemfile:
 - gemfiles/default.gemfile
 - gemfiles/rspec_2.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html