### PR TITLE
README: Travis badge to show status on master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This allows testing of both sides of an integration point using fast unit tests.
 
 This gem is inspired by the concept of "Consumer driven contracts". See [this article](http://martinfowler.com/articles/consumerDrivenContracts.html) by Ian Robinson for more information.
 
-Travis CI Status: [![travis-ci.org Build Status](https://travis-ci.org/realestate-com-au/pact.svg)](https://travis-ci.org/realestate-com-au/pact)
+Travis CI Status: [![travis-ci.org Build Status](https://travis-ci.org/realestate-com-au/pact.svg?branch=master)](https://travis-ci.org/realestate-com-au/pact)
 
 ## What is it good for?
 


### PR DESCRIPTION
This PR changes the Travis build badge to point at `master` to show _its_ build status.